### PR TITLE
feat: improve tracking of messages

### DIFF
--- a/lib/tohttp.js
+++ b/lib/tohttp.js
@@ -3,6 +3,7 @@
 var Response = require('./response')
     , _ = require('lodash')
     , http = require('http')
+    , server = http.createServer()
     , EventEmitter = require('events').EventEmitter;
 
 module.exports = toHttp;
@@ -13,7 +14,7 @@ function toHttp(app, queueImpl, subscriptionPath, filterFn) {
     subscriber.on('message', function (error, message) {
         if (error) {
             console.error('read message error ' + error.message);
-            subscriber.emit('ack');
+            subscriber.emit('ack', error, message);
             return message.ack();
         }
 
@@ -85,10 +86,19 @@ function toHttp(app, queueImpl, subscriptionPath, filterFn) {
 
                 queueImpl.send(replyTo, JSON.stringify(outgoingResponse));
                 message.ack();
-                subscriber.emit('ack');
+                subscriber.emit('ack', error, message);
+                // Notify listeners that the response is complete, the order of events
+                // is important, `close` must be the last one
+                res.emit('end');
+                res.emit('finish');
+                res.emit('close');
             }
         });
 
+        // Emit a request event on a mocked server, ideally it should be done on
+        // the actual server, but `app` doesn't hold a reference to it
+        // For tracking purposes however, emitting on this server has the same effect
+        server.emit('request', req, res);
         app.handle(req, res);
 
         // defer to satisfy formidable multipart parser


### PR DESCRIPTION
Pass errors and message to the `ack` listeners, it'll help tracking which requests have been acknowledged and which are still in flight.

Also emit events that enable tracking in opbeat and hopefully in other libraries as well, maybe newrelic?

@tombburnell @WebReflection 