### PR TITLE
fix: MOL-10288 set headers on empty body responses

### DIFF
--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -71,7 +71,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
             if (parsed.headers) {
                 setHeaders(res, parsed.headers, continuation);
             }
-            continuation.bodySample = httpBody.substring(0, 100);
+            continuation.bodySample = httpBody ? httpBody.substring(0, 100) : '';
 
             var byteLength = httpBody ? Buffer.byteLength(httpBody) : 0;
             continuation.bodyLength = continuation.bodyLength ? continuation.bodyLength + byteLength : byteLength;

--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -21,7 +21,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
     console.log("Subscribing to ReplyTo: ", replyTo);
     var subscriber = queueImpl.subscriber(replyTo);
-    subscriber.on('message', sendHttpResponse); // Received response message from queue 
+    subscriber.on('message', sendHttpResponse); // Received response message from queue
 
     function sendHttpResponse(error, message) {
         if (error) return console.error('read message error ' + error.message);
@@ -38,6 +38,16 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
         }
         message.ack();
+    }
+
+    function setHeaders(res, headers, continuation) {
+        if (!continuation.headersSent) {
+            continuation.headersSent = true;
+            Object.keys(headers).forEach(function (key) {
+                var value = headers[key];
+                res.setHeader(key, value);
+            });
+        }
     }
 
     function version2(parsed, continuations) {
@@ -59,10 +69,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
         if (parsed.first) {
             if (parsed.headers) {
-                Object.keys(parsed.headers).forEach(function (key) {
-                    var value = parsed.headers[key];
-                    res.setHeader(key, value);
-                });
+                setHeaders(res, parsed.headers, continuation);
             }
             continuation.bodySample = httpBody.substring(0, 100);
 
@@ -76,6 +83,9 @@ function fromHttp(app, queueImpl, opts, ttl) {
         }
 
         if (parsed.end) {
+            if (parsed.headers) {
+                setHeaders(res, parsed.headers, continuation);
+            }
 
             opts.postReceiveFn && opts.postReceiveFn(parsed, continuation);
             //console.log(continuation.req.method, 2, parsed.code, continuation.req.url, continuation.bodyLength, correlationId,  durationMs, parsed.headers['x-node'], continuation.bodySample);


### PR DESCRIPTION
Cuteyp sets the headers only on the first written chunk, however responses with empty body never call `writeFn` hence headers are never set.

You can check the behavior by creating a simple middleware

```js
app.get('/fruit', function (req, res) {
    res.setHeader('X-banana', 'yellow');
    res.status(204).end();
});
```

When hitting `/fruit` you get a `204` but the header `X-banana` is missing.

This PR modifies the behavior to set headers on the first message, either on the `writeFn` or `endFn`.

The change is needed to upgrade `passport` and `express4`.
As of passport `0.2.0`, as well as the latest `0.3.2`, the authenticator middleware was changed to the [following code](https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js#L310-L326) instead of the native `res.redirect`

```js
res.statusCode = status || 302;
res.setHeader('Location', url);
res.setHeader('Content-Length', '0');
res.end();
```

The unintended effect is that while the previous response was

```
HTTP1.1 302
Location: url
Content-Length: 1234

<p>Found. Redirecting to <a href="url">url</a></p>
```

it is now

```
HTTP1.1 302
Location: url
Content-Length: 0
```

which is a valid HTTP redirect, but once serialized from cuteyp, it comes out without the `Location` header.