### PR TITLE
fix: body can be empty when writing messages

### DIFF
--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -71,7 +71,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
             if (parsed.headers) {
                 setHeaders(res, parsed.headers, continuation);
             }
-            continuation.bodySample = httpBody.substring(0, 100);
+            continuation.bodySample = httpBody ? httpBody.substring(0, 100) : '';
 
             var byteLength = httpBody ? Buffer.byteLength(httpBody) : 0;
             continuation.bodyLength = continuation.bodyLength ? continuation.bodyLength + byteLength : byteLength;


### PR DESCRIPTION
Somewhat similar to #5 when upgrading to express4 and express-session, it happens that empty responses (304) go through `writeFn`.

This breaks when trying to build a `bodySample`.
It feels little controversial to guard against empty bodies because we're already doing it on the next line.