### PR TITLE
chore: dropping formidable library

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "body-parser": "^1.16.0",
     "eslint": "^3.14.0",
     "formidable": "^1.1.1",
-    "mocha": "^3.2.0",
+    "mocha": "^3.3.0",
     "mockery": "^2.0.0",
     "multiparty": "^4.1.3",
     "redis-mock": "^0.16.0",

--- a/test/service_mock.js
+++ b/test/service_mock.js
@@ -3,7 +3,7 @@
 var express = require('express')
     , cuteyp = require('../cuteyp')
     , bodyParser = require('body-parser')
-    , formidable = require('formidable')
+    , multiparty = require('multiparty')
     , fs = require('fs')
     , assert = require('assert');
 
@@ -52,13 +52,13 @@ module.exports = function(serviceName, opts) {
 
 
     function postImage(req, res) {
-        var form = new formidable.IncomingForm();
+        var form = new multiparty.Form();
         form.parse(req, function (err, fields, files) {
             if (err) return res.send(500, err);
 
             try {
                 assert.equal(fields.name, 'test');
-                var uploadedImgData = fs.readFileSync(files.logo.path);
+                var uploadedImgData = fs.readFileSync(files.logo[0].path);
                 var imgData = fs.readFileSync(__dirname + '/' + req.params.image);
                 assert.deepEqual(uploadedImgData, imgData);
                 res.set('Content-Type', 'text/plain');


### PR DESCRIPTION
Since current formidable status is not the best but there are similar alternatives, why not doing some little cleanup and switch to multiparty.

[multiparty](https://github.com/pillarjs/multiparty#multiparty) has more recent updates, less bugs, and some badge that at least doesn't say **build failure** plus 97% code coverage.

