### PR TITLE
fix: ensure formidable consumes posts with or without multipart data

### DIFF
--- a/lib/tohttp.js
+++ b/lib/tohttp.js
@@ -42,6 +42,46 @@ function toHttp(app, queueImpl, subscriptionPath, filterFn) {
             resume: function() {}
         });
 
+        // grab the inherited method
+        var originalON = req.on;
+
+        // redefine the method to handle data asked later on
+        // by formidable.parse(req) method
+        // (which adds listeners after but we don't know *when*)
+        req.on = function on(msg) {
+            // if the message is 'data'
+            if (msg === 'data') {
+                // flag this object synchronously
+                this._askedForData = true;
+                // emit 'data', if any, and 'end' next tick
+                // to allow chained listeners to be added
+                // after this req.on(...) call
+                Promise.resolve(this).then(function (self) {
+                    // emit the data only if there was some
+                    if (self._data) {
+                        self.emit('data', self._data);
+                    }
+                    // emit the end listener regardless
+                    self.emit('end');
+                });
+            }
+            // if message is 'end' and nobody asked for data
+            else if (msg === 'end' && !this._askedForData) {
+                // emit 'end' next tick
+                Promise.resolve(this).then(function (self) {
+                    // however, if some code added event
+                    // 'end' before 'data' for some reason,
+                    // do not emit 'end' again and just return
+                    // 'cause it would happen already via 'data'
+                    if (self._askedForData) return;
+                    self.emit('end');
+                });
+            }
+            // return whatever would've returned  the original .on()
+            return originalON.apply(this, arguments);
+        };
+
+
         _.extend(req, {
             headers: parsed.headers,
             url: parsed.url,
@@ -95,21 +135,17 @@ function toHttp(app, queueImpl, subscriptionPath, filterFn) {
             }
         });
 
+        if (parsed.body) {
+            req._data = parsed.headers["x-base64"] ? new Buffer(parsed.body, 'base64') : parsed.body;
+        }
+
         // Emit a request event on a mocked server, ideally it should be done on
         // the actual server, but `app` doesn't hold a reference to it
         // For tracking purposes however, emitting on this server has the same effect
         server.emit('request', req, res);
+
         app.handle(req, res);
 
-        // defer to satisfy formidable multipart parser
-        _.defer(function () {
-            // pass in body to request so that subscribers can pick it up (jsonparser, POST requests etc)
-            if (parsed.body) {
-                var data = parsed.headers["x-base64"] ? new Buffer(parsed.body, 'base64') : parsed.body;
-                req.emit('data', data);
-            }
-            req.emit('end');
-        });
     });
 
     return subscriber;


### PR DESCRIPTION
We currently are unable to upload GIFs (and probably something else) due a delay introduced by some middle layer that doesn't let formidable library listen properly to events already emitted.

This PR makes the fake socket object able to react to `data` and `end` listeners at distance, sending the data only if asked, and ASAP, still asynchronously.

This PR probably needs some integration test because everything mocked in our unit tests would never cause a problem that was intrinsic in half cuteyp and formidable (or really any other form uploader).