### PR TITLE
feat: MOL-13704 Migrate from node-redis to ioredis

### DIFF
--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -25,19 +25,20 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
     function sendHttpResponse(error, message) {
         if (error) return console.error('read message error ' + error.message);
+        if (message.body) {
+            var parsed = JSON.parse(message.body);
 
-        var parsed = JSON.parse(message.body);
+            switch (parsed.version) {
+                case 2:
+                    version2(parsed, continuations);
+                    break;
+                default:
+                    version1(parsed, continuations);
+                    break;
 
-        switch (parsed.version) {
-            case 2:
-                version2(parsed, continuations);
-                break;
-            default:
-                version1(parsed, continuations);
-                break;
-
+            }
+            message.ack();
         }
-        message.ack();
     }
 
     function setHeaders(res, headers, continuation) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,5 +1,5 @@
 'use strict';
-var Redis = require('ioredis');
+var IORedis = require('ioredis');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 const { flattenStack } = require('./utils');
@@ -14,8 +14,7 @@ function Redis(_options) {
 
     host = options.host;
     port = options.port;
-    commandClient = new Redis(port, host, options);
-
+    commandClient = new IORedis(port, host, options);
     commandClient.on('error', (err) => {
         console.error('METRIC ns="cc.cuteyp.redis.error" err="'+ flattenStack(err.stack) + '"');
     });
@@ -39,7 +38,7 @@ function Subscriber(subscriptionPath) {
     var self = this;
     console.log("Subscribing to", subscriptionPath);
 
-    self._subscriberClient = new Redis(port, host, options);
+    self._subscriberClient = new IORedis(port, host, options);
 
     self._subscriberClient.on('error', (err) => {
         console.error('METRIC ns="cc.cuteyp.subscriber.error" err="'+ flattenStack(err.stack) + '"');

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,7 +1,8 @@
 'use strict';
-var redis = require('redis');
+var Redis = require('ioredis');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+const { flattenStack } = require('./utils');
 
 var commandClient;
 var host, port, options;
@@ -13,7 +14,11 @@ function Redis(_options) {
 
     host = options.host;
     port = options.port;
-    commandClient = redis.createClient(port, host, options);
+    commandClient = new Redis(port, host, options);
+
+    commandClient.on('error', (err) => {
+        console.error('METRIC ns="cc.cuteyp.redis.error" err="'+ flattenStack(err.stack) + '"');
+    });
 
     return {
         subscriber: function(path) {
@@ -34,7 +39,11 @@ function Subscriber(subscriptionPath) {
     var self = this;
     console.log("Subscribing to", subscriptionPath);
 
-    self._subscriberClient = redis.createClient(port, host, options);
+    self._subscriberClient = new Redis(port, host, options);
+
+    self._subscriberClient.on('error', (err) => {
+        console.error('METRIC ns="cc.cuteyp.subscriber.error" err="'+ flattenStack(err.stack) + '"');
+    });
 
     self._subscriberClient.on('pmessage', function (pattern, channel, raw) {
         var message = {

--- a/lib/redislist.js
+++ b/lib/redislist.js
@@ -1,7 +1,8 @@
 'use strict';
-var redis = require('redis');
+var Redis = require('ioredis');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+const { flattenStack } = require('./utils');
 
 var commandClient;
 var port, host, options;
@@ -14,7 +15,11 @@ function RedisList(_options) {
     port = options.port;
     host = options.host;
     console.log("Cuteyp connecting to redis at", host, port);
-    commandClient = redis.createClient(port, host, options);
+    commandClient = new Redis(port, host, options);
+
+    commandClient.on('error', (err) => {
+        console.error('METRIC ns="cc.cuteyp.redislist.error" err="'+ flattenStack(err.stack) + '"');
+    });
 
     return {
         subscriber: function (path) {
@@ -40,7 +45,11 @@ function Subscriber(subscriptionPath) {
 
     console.log("Subscribing to", subscriptionPath);
 
-    self._subscriberClient = redis.createClient(port, host, options);
+    self._subscriberClient = new Redis(port, host, options);
+
+    self._subscriberClient.on('error', (err) => {
+        console.error('METRIC ns="cc.cuteyp.subscriber.error" err="'+ flattenStack(err.stack) + '"');
+    });
 
     queueNext();
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function flattenStack (stack) {
+    return (stack || '').toString().replace(/\n/g,'');
+}
+
+module.exports = { flattenStack };

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "body-parser": "^1.16.0",
     "eslint": "^3.14.0",
     "formidable": "^1.1.1",
+    "ioredis-mock": "^3.1.1",
     "mocha": "^3.2.0",
     "mockery": "^2.0.0",
     "multiparty": "^4.1.3",
-    "redis-mock": "^0.16.0",
     "supertest": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "license": "Private",
   "dependencies": {
     "express": "^3.21.2",
+    "ioredis": "^3.1.4",
     "lodash": "^4.17.4",
-    "redis": "^2.6.5",
     "stompit": "^0.24.0"
   },
   "devDependencies": {

--- a/test/queues_test.js
+++ b/test/queues_test.js
@@ -2,9 +2,16 @@
 
 var assert = require('assert');
 
+const RedisMock = require('ioredis-mock');
+
 var mockery = require('mockery')
     , stompMock = {};
-mockery.registerSubstitute('redis', 'redis-mock');
+
+RedisMock.prototype.brpop = function (subscriptionPath, i, queueFn) {
+    queueFn(undefined, []);
+};
+
+mockery.registerMock('ioredis', RedisMock);
 mockery.registerMock('stompit', stompMock);
 mockery.registerAllowables(['../lib/redis.js', '../lib/redislist.js', '../lib/stomp.js']);
 


### PR DESCRIPTION
http://andjira.and.dmgt.net:8080/browse/MOL-13704

This will provide a more stable and maintained redis library, with working retry/reconnection logic and error handling.

It also acts as the groundwork for eventual redis sentinal adoption should we want to.

#### Related
- https://github.com/MailOnline/deadbolt/pull/5
- https://github.com/MailOnline/cc-config/pull/46
- https://github.com/MailOnline/cc-common-be/pull/43
- https://github.com/MailOnline/cc-proxy/pull/9