### PR TITLE
fix: process dies on slow response

### DIFF
--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -203,7 +203,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
                     var c = continuations[correlationId];
                     opts.timeoutFn && opts.timeoutFn(correlationId, c);
                     delete continuations[correlationId];
-                    res.send(500, "Failed to get response from endpoint");
+                    res.status(500).end("Failed to get response from endpoint");
                 }
             }, 60000);
 

--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -80,6 +80,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
         if (httpBody) {
             if (parsed.isBinary) httpBody = new Buffer(httpBody, 'base64');
+            continuation.resetTimeout && continuation.resetTimeout();
             res.write(httpBody);
         }
 
@@ -180,6 +181,16 @@ function fromHttp(app, queueImpl, opts, ttl) {
             //it needs to be the original body length, not Buffer.byteLength
             if (req.body) req.headers['content-length'] = req.body.length;
 
+            // clear out continuation if not used after some period of time
+            const timeoutDebounce = _.debounce(function () {
+                if (continuations[correlationId]) {
+                    var c = continuations[correlationId];
+                    opts.timeoutFn && opts.timeoutFn(correlationId, c);
+                    delete continuations[correlationId];
+                    res.status(500).end("Failed to get response from endpoint");
+                }
+            }, 60000);
+
             var msg = {
                 headers: req.headers,
                 url: req.url,
@@ -194,18 +205,11 @@ function fromHttp(app, queueImpl, opts, ttl) {
                 reqTime: process.hrtime(),
                 req: req,
                 res: res,
-                next: next
+                next: next,
+                resetTimeout: timeoutDebounce
             };
 
-            // clear out continuation if not used after some period of time
-            setTimeout(function () {
-                if (continuations[correlationId]) {
-                    var c = continuations[correlationId];
-                    opts.timeoutFn && opts.timeoutFn(correlationId, c);
-                    delete continuations[correlationId];
-                    res.status(500).end("Failed to get response from endpoint");
-                }
-            }, 60000);
+            timeoutDebounce();
 
             var outgoingBody = JSON.stringify(msg);
 

--- a/lib/fromhttp.js
+++ b/lib/fromhttp.js
@@ -80,7 +80,7 @@ function fromHttp(app, queueImpl, opts, ttl) {
 
         if (httpBody) {
             if (parsed.isBinary) httpBody = new Buffer(httpBody, 'base64');
-            continuation.resetTimeout && continuation.resetTimeout();
+            continuation.resetTimeout();
             res.write(httpBody);
         }
 


### PR DESCRIPTION
This uncaught exception is causing node process to die on slow connection. 

Also we are debouncing timeout now when a response is received. 

```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```

Services reply to proxy in multiple chunks, when setTimeout kicks in between a response write and response end this error happens. 
