### PR TITLE
fix: express4 broken session handling

### DIFF
--- a/lib/tohttp.js
+++ b/lib/tohttp.js
@@ -96,7 +96,7 @@ function toHttp(app, queueImpl, subscriptionPath, filterFn) {
                 };
 
                 if (!this._headersSent) {
-                    res.emit('header'); // forces headers to be set
+                    res.flushHeaders(); // forces headers to be set
                     this._headersSent = true;
                     outgoingResponse.first = true;
                     outgoingResponse.headers = res._headers;


### PR DESCRIPTION
`res.emit('header');` is deprecated since connect v2.16.0

https://github.com/senchalabs/connect/blob/master/HISTORY.md#2160--2014-05-17